### PR TITLE
fix: configure vue-cli to transpile es modules in jest env

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,6 @@
+process.env.VUE_CLI_BABEL_TRANSPILE_MODULES = true
+process.env.VUE_CLI_BABEL_TARGET_NODE = 'node'
+
 module.exports = {
   presets: [
     '@vue/app'


### PR DESCRIPTION
These flags are present in the main book repo.

They were missing from this secondary repo, so the tests were breaking because of a transpilation error.